### PR TITLE
Revert "omaha_request_params: default to using ServiceEnvironment and…

### DIFF
--- a/src/update_engine/omaha_request_params.cc
+++ b/src/update_engine/omaha_request_params.cc
@@ -56,11 +56,7 @@ bool OmahaRequestParams::Init(bool interactive) {
   interactive_ = interactive;
   session_uuid_ = utils::GetUuid();
 
-  app_channel_ = GetConfValue("ServiceEnvironment", "");
-  if (app_channel_ == "") {
-      app_channel_ = GetConfValue("GROUP", kDefaultChannel);
-  }
-
+  app_channel_ = GetConfValue("GROUP", kDefaultChannel);
   LOG(INFO) << "Current group set to " << app_channel_;
 
   // deltas are only okay if the /.nodelta file does not exist.  if we don't


### PR DESCRIPTION
… not GROUP in the config file"

This reverts commit 6380f621124270e8ec97327cce1f22b6d9ba77ca.

This allows separating the cloud backend from the update engine group (again)