### PR TITLE
Pass version from server to postinstall script

### DIFF
--- a/remarkable-postinst
+++ b/remarkable-postinst
@@ -9,6 +9,13 @@ umask 0022
 
 INSTALL_MNT=$(dirname "$0")
 INSTALL_DEV="$1"
+NEW_VERSION=""
+
+for arg in "$@"; do
+    case "${arg}" in
+        NEW_VERSION=*) NEW_VERSION="${arg#NEW_VERSION=}" ;;
+    esac
+done
 
 # use the fw_setenv binary from the image to ensure compatibility
 FW_SETENV=

--- a/src/update_engine/install_plan.cc
+++ b/src/update_engine/install_plan.cc
@@ -50,6 +50,10 @@ bool InstallPlan::operator!=(const InstallPlan &that) const
 
 void InstallPlan::Dump() const
 {
+    string arg_list;
+    for (const string &arg : postinst_args) {
+        arg_list += arg;
+    }
     LOG(INFO) << "InstallPlan: "
               << (is_resume ? ", resume" : ", new_update")
               << ", url: " << download_url
@@ -57,6 +61,7 @@ void InstallPlan::Dump() const
               << ", payload hash: " << payload_hash
               << ", partition_path: " << partition_path
               << ", kernel_path: " << kernel_path
+              << ", postinst_args: " << arg_list
               << ", old_partition_path: " << old_partition_path
               << ", old_kernel_path: " << old_kernel_path;
 }

--- a/src/update_engine/omaha_request_params.cc
+++ b/src/update_engine/omaha_request_params.cc
@@ -27,16 +27,20 @@ namespace chromeos_update_engine {
 
 const char *const OmahaRequestParams::kAppId(
     "{98DA7DF2-4E3E-4744-9DE6-EC931886ABAB}");
+const char *const OmahaRequestParams::kOsVersion("codex");
 const char *const OmahaRequestParams::kOsPlatform("reMarkable");
-const char *const OmahaRequestParams::kOsVersion("zg");
 const char *const OmahaRequestParams::kDefaultChannel("stable");
 const char *const kProductionOmahaUrl(
     "https://updates.cloud.remarkable.engineering/service/update2");
 
 bool OmahaRequestParams::Init(bool interactive)
 {
-    os_platform_ = OmahaRequestParams::kOsPlatform;
     os_version_ = OmahaRequestParams::kOsVersion;
+    if ( GetOemValue("ID", "") == "codex" ) {
+        os_version_ += " " + GetOemValue("VERSION_ID", "");
+    }
+
+    os_platform_ = OmahaRequestParams::kOsPlatform;
     if (utils::GetMachineModel().find("reMarkable 2.0") != string::npos) {
         os_platform_ = "RM110";
     }

--- a/src/update_engine/omaha_request_params.cc
+++ b/src/update_engine/omaha_request_params.cc
@@ -45,19 +45,22 @@ bool OmahaRequestParams::Init(bool interactive)
         os_platform_ = "RM110";
     }
 
+    os_sp_ = app_version_ + "_" + GetMachineType();
+    os_board_ = GetConfValue("REMARKABLE_RELEASE_BOARD", "");
+
+    app_id_ = GetConfValue("REMARKABLE_RELEASE_APPID", OmahaRequestParams::kAppId);
+    app_channel_ = GetConfValue("GROUP", kDefaultChannel);
+    app_lang_ = "en-US";
+    app_version_ = GetConfValue("REMARKABLE_RELEASE_VERSION", "");
+
     oemid_ = GetConfValue("deviceid", "");
     oemversion_ = GetOemValue("VERSION_ID", "");
-    app_version_ = GetConfValue("REMARKABLE_RELEASE_VERSION", "");
 
     if (!system_state_->prefs()->GetString(kPrefsAlephVersion, &alephversion_)) {
         alephversion_.assign(app_version_);
         system_state_->prefs()->SetString(kPrefsAlephVersion, alephversion_);
     }
 
-    os_sp_ = app_version_ + "_" + GetMachineType();
-    os_board_ = GetConfValue("REMARKABLE_RELEASE_BOARD", "");
-    app_id_ = GetConfValue("REMARKABLE_RELEASE_APPID", OmahaRequestParams::kAppId);
-    app_lang_ = "en-US";
     bootid_ = utils::GetBootId();
     machineid_ = utils::GetMachineId();
     arch_ = GetMachineType();
@@ -65,7 +68,6 @@ bool OmahaRequestParams::Init(bool interactive)
     interactive_ = interactive;
     session_uuid_ = utils::GetUuid();
 
-    app_channel_ = GetConfValue("GROUP", kDefaultChannel);
     LOG(INFO) << "Current group set to " << app_channel_;
 
     // deltas are only okay if the /.nodelta file does not exist.  if we don't

--- a/src/update_engine/omaha_request_params.cc
+++ b/src/update_engine/omaha_request_params.cc
@@ -37,6 +37,10 @@ bool OmahaRequestParams::Init(bool interactive)
 {
     os_platform_ = OmahaRequestParams::kOsPlatform;
     os_version_ = OmahaRequestParams::kOsVersion;
+    if (utils::GetMachineModel().find("reMarkable 2.0") != string::npos) {
+        os_platform_ = "RM110";
+    }
+
     oemid_ = GetConfValue("deviceid", "");
     oemversion_ = GetOemValue("VERSION_ID", "");
     app_version_ = GetConfValue("REMARKABLE_RELEASE_VERSION", "");

--- a/src/update_engine/omaha_request_params.cc
+++ b/src/update_engine/omaha_request_params.cc
@@ -29,9 +29,9 @@ const char *const OmahaRequestParams::kAppId(
     "{98DA7DF2-4E3E-4744-9DE6-EC931886ABAB}");
 const char *const OmahaRequestParams::kOsVersion("codex");
 const char *const OmahaRequestParams::kOsPlatform("reMarkable");
-const char *const OmahaRequestParams::kDefaultChannel("stable");
+const char *const OmahaRequestParams::kDefaultChannel("Prod");
 const char *const kProductionOmahaUrl(
-    "https://updates.cloud.remarkable.engineering/service/update2");
+    "https://get-updates.cloud.remarkable.engineering/service/update2");
 
 bool OmahaRequestParams::Init(bool interactive)
 {

--- a/src/update_engine/omaha_response_handler_action.cc
+++ b/src/update_engine/omaha_response_handler_action.cc
@@ -42,9 +42,12 @@ void OmahaResponseHandlerAction::PerformAction()
     // All decisions as to which URL should be used have already been done. So,
     // make the download URL as the payload URL at the current url index.
     uint32_t url_index = system_state_->payload_state()->GetUrlIndex();
-    LOG(INFO) << "Using Url" << url_index << " as the download url this time";
+    LOG(INFO) << "Using Url " << url_index << " as the download url this time";
     CHECK(url_index < response.payload_urls.size());
     install_plan_.download_url = response.payload_urls[url_index];
+
+    install_plan_.postinst_args.push_back(
+            "NEW_VERSION=" + response.display_version);
 
     // Fill up the other properties based on the response.
     install_plan_.display_version = response.display_version;

--- a/src/update_engine/omaha_response_handler_action_unittest.cc
+++ b/src/update_engine/omaha_response_handler_action_unittest.cc
@@ -108,6 +108,12 @@ TEST_F(OmahaResponseHandlerActionTest, SimpleTest)
         EXPECT_EQ(in.hash, install_plan.payload_hash);
         EXPECT_EQ(in.display_version, install_plan.display_version);
         EXPECT_EQ("/dev/sda3", install_plan.partition_path);
+
+        const string expected_version = "NEW_VERSION=" + in.display_version;
+        EXPECT_NE(std::find(install_plan.postinst_args.begin(), install_plan.postinst_args.end(),
+                    expected_version),
+                install_plan.postinst_args.end());
+
         string deadline;
         EXPECT_TRUE(utils::ReadFile(
                         OmahaResponseHandlerAction::kDeadlineFile,

--- a/src/update_engine/utils.cc
+++ b/src/update_engine/utils.cc
@@ -64,6 +64,7 @@ static const char kBootId[] = "/proc/sys/kernel/random/boot_id";
 static const char kMachineId[] = "/etc/machine-id";
 static const char kDevImageMarker[] = "/root/.dev_mode";
 static const char kGenUuid[] = "/proc/sys/kernel/random/uuid";
+static const char kMachineModel[] = "/sys/devices/soc0/machine";
 
 bool IsOfficialBuild()
 {
@@ -125,6 +126,20 @@ string GetUuid()
     guid.append(id);
     guid.append(1, '}');
     return guid;
+}
+
+string GetMachineModel()
+{
+    string machine;
+
+    if (!files::ReadFileToString(files::FilePath(kMachineModel), &machine)) {
+        LOG(ERROR) << "Unable to read machine model";
+        return "";
+    }
+
+    machine = strings::TrimWhitespace(machine);
+
+    return machine;
 }
 
 bool WriteFile(const char *path, const char *data, int data_len)

--- a/src/update_engine/utils.h
+++ b/src/update_engine/utils.h
@@ -46,6 +46,8 @@ std::string GetMachineId();
 // Creates and returns a new uuid
 std::string GetUuid();
 
+std::string GetMachineModel();
+
 // Writes the data passed to path. The file at path will be overwritten if it
 // exists. Returns true on success, false otherwise.
 bool WriteFile(const char *path, const char *data, int data_len);

--- a/systemd/update-engine.service
+++ b/systemd/update-engine.service
@@ -6,7 +6,7 @@ ConditionPathExists=!/usr/.noupdate
 [Service]
 Type=dbus
 BusName=no.remarkable.update1
-ExecStart=/usr/sbin/update_engine -foreground -logtostderr
+ExecStart=/usr/sbin/update_engine -foreground
 BlockIOWeight=100
 Restart=always
 RestartSec=30


### PR DESCRIPTION
Also added tests to verify that the version we get from the server is passed to the InstallPlan, and that the version is passed from there to the postinstall script itself.

Need to run the root tests (so run with sudo) to verify this, though. I created a separate branch to try to get the tests to run without root, but that's a bit more tricky.