### PR TITLE
cleanup omaha_request_params

### DIFF
--- a/src/update_engine/omaha_request_params.cc
+++ b/src/update_engine/omaha_request_params.cc
@@ -49,7 +49,7 @@ bool OmahaRequestParams::Init(bool interactive)
     os_board_ = GetConfValue("REMARKABLE_RELEASE_BOARD", "");
 
     app_id_ = GetConfValue("REMARKABLE_RELEASE_APPID", OmahaRequestParams::kAppId);
-    app_channel_ = GetConfValue("GROUP", kDefaultChannel);
+    app_channel_ = GetConfValue("CHANNEL", kDefaultChannel);
     app_lang_ = "en-US";
     app_version_ = GetConfValue("REMARKABLE_RELEASE_VERSION", "");
 

--- a/src/update_engine/omaha_request_params.cc
+++ b/src/update_engine/omaha_request_params.cc
@@ -42,7 +42,7 @@ bool OmahaRequestParams::Init(bool interactive)
 
     os_platform_ = OmahaRequestParams::kOsPlatform;
     if (utils::GetMachineModel().find("reMarkable 2.0") != string::npos) {
-        os_platform_ = "RM110";
+        os_platform_ = "reMarkable2";
     }
 
     os_sp_ = app_version_ + "_" + GetMachineType();


### PR DESCRIPTION
* Rename GROUP to CHANNEL to be represent what it's actually called in Omaha UI
* Change default platform for `reMarkable 1.0`