### PR TITLE
omaha_request_params: set platform for reMarkable 2.0 to reMarkable2

### DIFF
--- a/src/update_engine/omaha_request_params.cc
+++ b/src/update_engine/omaha_request_params.cc
@@ -42,7 +42,7 @@ bool OmahaRequestParams::Init(bool interactive)
 
     os_platform_ = OmahaRequestParams::kOsPlatform;
     if (utils::GetMachineModel().find("reMarkable 2.0") != string::npos) {
-        os_platform_ = "RM110";
+        os_platform_ = "reMarkable2";
     }
 
     os_sp_ = app_version_ + "_" + GetMachineType();


### PR DESCRIPTION
Replaces #4