### PR TITLE
omaha_request_params: rename GROUP to CHANNEL to reflect usage

### DIFF
--- a/src/update_engine/omaha_request_params.cc
+++ b/src/update_engine/omaha_request_params.cc
@@ -49,7 +49,7 @@ bool OmahaRequestParams::Init(bool interactive)
     os_board_ = GetConfValue("REMARKABLE_RELEASE_BOARD", "");
 
     app_id_ = GetConfValue("REMARKABLE_RELEASE_APPID", OmahaRequestParams::kAppId);
-    app_channel_ = GetConfValue("GROUP", kDefaultChannel);
+    app_channel_ = GetConfValue("CHANNEL", kDefaultChannel);
     app_lang_ = "en-US";
     app_version_ = GetConfValue("REMARKABLE_RELEASE_VERSION", "");
 


### PR DESCRIPTION
replaces parts of #4