### PR TITLE
payload_processor: look for public key in home directory first

### DIFF
--- a/src/update_engine/omaha_request_params.cc
+++ b/src/update_engine/omaha_request_params.cc
@@ -45,13 +45,14 @@ bool OmahaRequestParams::Init(bool interactive)
         os_platform_ = "reMarkable2";
     }
 
-    os_sp_ = app_version_ + "_" + GetMachineType();
-    os_board_ = GetConfValue("REMARKABLE_RELEASE_BOARD", "");
 
     app_id_ = GetConfValue("REMARKABLE_RELEASE_APPID", OmahaRequestParams::kAppId);
     app_channel_ = GetConfValue("GROUP", kDefaultChannel);
     app_lang_ = "en-US";
     app_version_ = GetConfValue("REMARKABLE_RELEASE_VERSION", "");
+
+    os_sp_ = app_version_ + "_" + GetMachineType();
+    os_board_ = GetConfValue("REMARKABLE_RELEASE_BOARD", "");
 
     oemid_ = GetConfValue("deviceid", "");
     oemversion_ = GetOemValue("VERSION_ID", "");

--- a/src/update_engine/omaha_request_params_unittest.cc
+++ b/src/update_engine/omaha_request_params_unittest.cc
@@ -140,7 +140,7 @@ TEST_F(OmahaRequestParamsTest, MissingChannelTest)
     EXPECT_EQ("{98DA7DF2-4E3E-4744-9DE6-EC931886ABAB}", out.app_id());
     EXPECT_EQ("0.2.2.3", out.app_version());
     EXPECT_EQ("en-US", out.app_lang());
-    EXPECT_EQ("stable", out.app_channel());
+    EXPECT_EQ("Prod", out.app_channel());
 }
 
 TEST_F(OmahaRequestParamsTest, ConfusingReleaseTest)
@@ -157,7 +157,7 @@ TEST_F(OmahaRequestParamsTest, ConfusingReleaseTest)
     EXPECT_EQ("{98DA7DF2-4E3E-4744-9DE6-EC931886ABAB}", out.app_id());
     EXPECT_EQ("0.2.2.3", out.app_version());
     EXPECT_EQ("en-US", out.app_lang());
-    EXPECT_EQ("stable", out.app_channel());
+    EXPECT_EQ("Prod", out.app_channel());
 }
 
 TEST_F(OmahaRequestParamsTest, MissingVersionTest)

--- a/src/update_engine/payload_processor.cc
+++ b/src/update_engine/payload_processor.cc
@@ -70,6 +70,11 @@ PayloadProcessor::PayloadProcessor(PrefsInterface *prefs, InstallPlan *install_p
       last_updated_buffer_offset_(std::numeric_limits<uint64_t>::max()),
       public_key_path_(kUpdatePayloadPublicKeyPath)
 {
+    const std::string overrideUpdatePayloadPublicKeyPath =
+        "/home/root/.update_engine/update-payload-key.pub.pem";
+    if (utils::FileExists(overrideUpdatePayloadPublicKeyPath.c_str())) {
+        public_key_path_ = overrideUpdatePayloadPublicKeyPath;
+    }
 }
 
 int PayloadProcessor::Open()

--- a/src/update_engine/payload_processor.h
+++ b/src/update_engine/payload_processor.h
@@ -29,6 +29,7 @@ class PayloadProcessor : public FileWriter
 public:
 
     static const char kUpdatePayloadPublicKeyPath[];
+    static const char kUpdatePayloadPublicKeyOverridePath[];
 
     PayloadProcessor(PrefsInterface *prefs, InstallPlan *install_plan);
 
@@ -157,6 +158,11 @@ private:
     // The public key to be used. Provided as a member so that tests can
     // override with test keys.
     std::string public_key_path_;
+
+    // An alternative public key to use. If it exists this will be used
+    // otherwise public_key_path_ is used. Provided as a member so that
+    // tests can override with test keys.
+    std::string public_key_override_path_;
 
     DISALLOW_COPY_AND_ASSIGN(PayloadProcessor);
 };


### PR DESCRIPTION
Allow overriding public key by letting payload_processor first
look for a public key in home directory, and use this one if found.